### PR TITLE
64k buffer for entries

### DIFF
--- a/entry_reader.go
+++ b/entry_reader.go
@@ -5,6 +5,10 @@ import (
 	"io"
 )
 
+const (
+	readerSize = 64 * 1024
+)
+
 type entryReader struct {
 	reader       *bufio.Reader
 	unmarshaller Unmarshaller
@@ -21,7 +25,7 @@ func newEntryReader(
 	options EntryReaderOptions,
 ) (*entryReader, error) {
 	obj := &entryReader{
-		bufio.NewReader(reader),
+		bufio.NewReaderSize(reader, readerSize),
 		unmarshaller,
 		decoder,
 		options,


### PR DESCRIPTION
By default a bufio.NewReader only has 4096 bytes of buffer. This makes it 64k. Should help with full buffers. Works w/ make dev.

@bfosberry 
