### PR TITLE
straight io

### DIFF
--- a/decoders.go
+++ b/decoders.go
@@ -1,10 +1,6 @@
 package ledge
 
-import (
-	"bufio"
-	"fmt"
-	"strconv"
-)
+import "bufio"
 
 var (
 	rpcDecoderInstance = &rpcDecoder{}
@@ -13,30 +9,5 @@ var (
 type rpcDecoder struct{}
 
 func (r *rpcDecoder) Decode(bufReader *bufio.Reader) ([]byte, error) {
-	slice, err := bufReader.ReadSlice(separatorBytes[0])
-
-	if err != nil {
-		return nil, err
-	}
-	sizeBytesLenBuf := int64(slice[0])
-	offset := int64(1)
-
-	sizeBytes := slice[offset : offset+sizeBytesLenBuf]
-	offset = offset + sizeBytesLenBuf
-	size, err := strconv.ParseInt(string(sizeBytes), 10, 64)
-	if err != nil {
-		return nil, err
-	}
-	sizeInt := int(size)
-	if int64(sizeInt) != size {
-		return nil, fmt.Errorf("ledge: could not cast %d to an int", size)
-	}
-
-	data := slice[offset : offset+size]
-
-	// docker logs do not flush without a newline, this is the hack
-	if int64(len(data)) > size {
-		return nil, fmt.Errorf("ledge: unexpected data size: %d vs %d - %s", len(data), size, string(slice))
-	}
-	return data, nil
+	return bufReader.ReadSlice(separator)
 }

--- a/encoders.go
+++ b/encoders.go
@@ -2,16 +2,13 @@ package ledge
 
 import (
 	"errors"
-	"fmt"
 	"io"
-	"strconv"
 )
 
 var (
 	rpcEncoderInstance = &rpcEncoder{}
 
 	separator                      = byte('\n')
-	separatorBytes                 = []byte{separator}
 	errShouldNotBeWritingZeroBytes = errors.New("ledge: should not be writing 0 bytes")
 )
 
@@ -21,43 +18,5 @@ func (r *rpcEncoder) Encode(writer io.Writer, data []byte) (int, error) {
 	if len(data) == 0 {
 		return 0, nil
 	}
-	size := strconv.FormatInt(int64(len(data)), 10)
-	sizeBytes := []byte(size)
-	sizeBytesLen := len(sizeBytes)
-	sizeBytesLenByte := byte(sizeBytesLen)
-	if int(sizeBytesLenByte) != sizeBytesLen {
-		return 0, fmt.Errorf("ledge: could not cast %d to a byte", sizeBytesLen)
-	}
-	if err := r.write(writer, []byte{sizeBytesLenByte}); err != nil {
-		return 0, err
-	}
-	if err := r.write(writer, sizeBytes); err != nil {
-		return 0, err
-	}
-	if err := r.write(writer, data); err != nil {
-		return 0, err
-	}
-	// docker logs do not flush without a newline, this is the hack
-	if err := r.writeSeparator(writer); err != nil {
-		return 0, err
-	}
-	return len(data), nil
-}
-
-func (r *rpcEncoder) write(writer io.Writer, p []byte) error {
-	if len(p) == 0 {
-		return errShouldNotBeWritingZeroBytes
-	}
-	n, err := writer.Write(p)
-	if err != nil {
-		return err
-	}
-	if n != len(p) {
-		return fmt.Errorf("ledge: tried to write %d bytes, wrote %d", len(p), n)
-	}
-	return nil
-}
-
-func (r *rpcEncoder) writeSeparator(writer io.Writer) error {
-	return r.write(writer, separatorBytes)
+	return writer.Write(append(data, separator))
 }

--- a/encoders.go
+++ b/encoders.go
@@ -1,22 +1,14 @@
 package ledge
 
-import (
-	"errors"
-	"io"
-)
+import "io"
 
 var (
 	rpcEncoderInstance = &rpcEncoder{}
-
-	separator                      = byte('\n')
-	errShouldNotBeWritingZeroBytes = errors.New("ledge: should not be writing 0 bytes")
+	separator          = byte('\n')
 )
 
 type rpcEncoder struct{}
 
 func (r *rpcEncoder) Encode(writer io.Writer, data []byte) (int, error) {
-	if len(data) == 0 {
-		return 0, nil
-	}
 	return writer.Write(append(data, separator))
 }


### PR DESCRIPTION
All the size writing and reading isn't needed. We can just read by the separator. This works with make dev.
# DO NOT MERGE

This changes how data is encoded and decoded. That means all running builds will have to be stopped, then this is deployed to janus and jetter, then builds can be run again. Any running build during the deploy would not have readable log data.

Hopefully #2 fixes our issues, but we can resort to this if we have to.

@bfosberry 
