### PR TITLE
Adding support for vendored packages

### DIFF
--- a/reflect_type_provider.go
+++ b/reflect_type_provider.go
@@ -3,6 +3,11 @@ package ledge
 import (
 	"fmt"
 	"reflect"
+	"strings"
+)
+
+const (
+	vendorSep = "/vendor/"
 )
 
 type reflectTypeProvider struct {
@@ -78,10 +83,23 @@ func (r *reflectTypeProvider) validateReflectType(m map[reflect.Type]bool, refle
 func addToKeyToReflectType(keyToReflectType map[string]reflect.Type, reflectTypes map[reflect.Type]bool, t interface{}) error {
 	reflectType := reflect.TypeOf(t)
 	key, err := getReflectTypeName(reflectType)
+	key = trimVendoring(key)
 	if err != nil {
 		return err
 	}
 	keyToReflectType[key] = reflectType
 	reflectTypes[reflectType] = true
 	return nil
+}
+
+func trimVendoring(key string) string {
+	if strings.Contains(key, vendorSep) {
+		endIndex := strings.Index(key, vendorSep)
+		startIndex := 1
+		if strings.HasPrefix(key, "*") {
+			startIndex = 2
+		}
+		key = key[0:startIndex] + key[endIndex+len(vendorSep):len(key)]
+	}
+	return key
 }


### PR DESCRIPTION
This is a temporary patch only. We need to figure out how we want to support messaging in the future without using the reflect package, but for now this will allow us to use go1.6 vendoring with go-ledge.

This change manipulates the strings to ensure the messages match between vendored types:

Normally: `"github.com/codeship/jet/log".Category` matches to type `jet_log.Category` stored in a map.

With references specification for jet_log under the vendor folder we receive a `"github.com/codeship/jet/log".Category` type, but our understanding of the specification maps `"github.com/codeship/janus/vendor/github.com/codeship/jet/log".Category` to jet_log.Category instead. This results in the incoming message not having a type to unmarhsal into.

This change strips out anything before "vendor". The downside of this approach is that any packages called "vendor" which are not top level might get corrupted. Since this lib is scoped to our use this is pretty low risk
