### PR TITLE
Increase Reader Buffer Size

### DIFF
--- a/entry_reader.go
+++ b/entry_reader.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	readerSize = 64 * 1024
+	readerSize = 256 * 1024
 )
 
 type entryReader struct {


### PR DESCRIPTION
Big steps payloads are leading to failing builds because the protobuf
payload is bigger than this buffer. This leads to the steps not being
unmarshalled correctly and subsequently not getting inserted. Until we
finally remove this package lets up the buffer size and measure the
impact. I estimate this should provide enough space for our current
customers problem.