### PR TITLE
Use ReadBytes over ReadSlice

### DIFF
--- a/decoders.go
+++ b/decoders.go
@@ -9,5 +9,5 @@ var (
 type rpcDecoder struct{}
 
 func (r *rpcDecoder) Decode(bufReader *bufio.Reader) ([]byte, error) {
-	return bufReader.ReadSlice(separator)
+	return bufReader.ReadBytes(separator)
 }


### PR DESCRIPTION
ReadBytes grows its return buffer until it reaches the delimeter. Rather
than just exploding with a ErrBufferFull. Infact it uses ReadSlice and
when it see's this error it grows it accomodate.

https://golang.org/src/bufio/bufio.go?s=10730:10784#L401

I couldn't see any concious decision to use ReadSlice over ReadBytes. I
could be mistaken though. I just happened to be reading the bufio source
for another thing and remembered we had the buffer full issue.